### PR TITLE
Fixed bug in calling gh-pages package incorrectly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: node
+          node-version: node #latest version
       - name: Install dependencies
         run: npm install
+      - name: Build
+        run: npm run build
       - name: Deploy with gh-pages
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npm run deploy -u "github-actions-bot <support+actions@github.com>"
+          npx gh-pages -d build -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
gh-pages package was being called incorrectly, which meant the git user name and email config settings were not being set, meaning the package could not checkout the files required to the gh-pages branch for deployment